### PR TITLE
Шрифти, точка перелому, відступи

### DIFF
--- a/src/partials/header.html
+++ b/src/partials/header.html
@@ -27,20 +27,23 @@
       </li>
     </ul>
   </nav>
+
   <!-- Навігація для мобілки (бургер-меню) -->
   <nav class="header-nav-mobile" aria-label="Main Navigation for Mobile">
-    <!--Кнопка відкриття мобільного меню-->
     <img class="header-logo" src="./img/home/logo.png" alt="logo-game" />
+    <!--Кнопка відкриття мобільного меню-->
     <button class="burger-menu" aria-label="Open Navigation">
       <span class="burger-line"></span>
       <span class="burger-line"></span>
       <span class="burger-line"></span>
     </button>
-    <!--Кнопка закриття мобільного меню-->
+
     <ul class="header-nav-list-mobile">
+      <!--Кнопка закриття мобільного меню-->
       <button class="close-menu" aria-label="Close Navigation">
         <img src="./img/home/Burger menu.svg" alt="Close menu" />
       </button>
+
       <li class="header-nav-list-item-mobile">
         <a class="header-nav-link-mobile" href="#home">Home</a>
       </li>

--- a/src/scss/aboutus.scss
+++ b/src/scss/aboutus.scss
@@ -4,6 +4,10 @@
   background: $_yellow_text_color;
 }
 
+.container-aboutus {
+  padding: 0 200px;
+}
+
 .aboutus-title {
   font-family: Norican;
   font-size: 40px;
@@ -28,11 +32,12 @@
 }
 
 /* Для ширших екранів (планшети та ПК) */
-@media screen and (min-width: 768px) {
+@media screen and (min-width: 1199px) {
   .container-aboutus {
     display: inline-block;
     height: 509px;
     width: 100%;
+    padding: 0 0;
   }
 
   .aboutus-text {
@@ -72,7 +77,7 @@
     flex-shrink: 0;
   }
 }
-@media screen and (max-width: 1200px) {
+@media screen and (max-width: 1199px) {
   .aboutus-images {
     display: none;
   }

--- a/src/scss/benefits.scss
+++ b/src/scss/benefits.scss
@@ -118,6 +118,7 @@
   .benefits-list-item-desc {
     position: absolute;
     display: block;
+    text-align: center;
     width: 90%;
     top: 55%;
     left: 50%;
@@ -126,7 +127,6 @@
     font-size: 24px;
     font-weight: 500;
     line-height: 36px;
-    text-align: center;
   }
   .benefits-img-wrap {
     position: absolute;

--- a/src/scss/faq.scss
+++ b/src/scss/faq.scss
@@ -1,6 +1,6 @@
 @import './common/vars.scss';
 
-@media screen and (min-width: 768px) {
+@media screen and (min-width: 1000px) {
   .faq-section {
     display: flex;
     flex-wrap: nowrap;
@@ -56,7 +56,7 @@
     padding-bottom: 32px;
   }
 }
-@media screen and (max-width: 768px) {
+@media screen and (max-width: 1000px) {
   .faq-section {
     display: flex;
     flex-wrap: nowrap;

--- a/src/scss/footer.scss
+++ b/src/scss/footer.scss
@@ -16,11 +16,13 @@
 }
 
 .footer-text {
-  text-align: center;
   color: $_main_text_color;
+  text-align: center;
   font-family: Inter;
-  font-size: 16px;
-  line-height: 18px;
+  font-size: 18px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 100%; /* 18px */
   flex: 1;
   margin-left: 250px;
 }
@@ -39,9 +41,16 @@
 
 .footer-nav-item {
   color: $_main_text_color;
+  text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  -webkit-text-stroke-width: 1;
+  -webkit-text-stroke-color: #000;
+  text-align: right;
   font-family: Inter;
-  font-size: 16px;
-  line-height: 18px;
+  font-size: 18px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 100%; /* 18px */
+  text-decoration-line: underline;
 }
 
 .footer-nav-span {
@@ -79,6 +88,16 @@
   }
 
   .footer-nav-item {
+    color: var(--White, #fff);
+    text-align: center;
+    text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+    -webkit-text-stroke-width: 1;
+    -webkit-text-stroke-color: #000;
+    font-family: Inter;
+    font-size: 18px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 100%; /* 18px */
     padding-bottom: 8px;
   }
 

--- a/src/scss/gallery.scss
+++ b/src/scss/gallery.scss
@@ -59,8 +59,8 @@ button img {
   height: 44px;
 }
 
-/* Стилі для великих екранів (768px і більше) */
-@media (min-width: 768px) {
+/* Стилі для великих екранів */
+@media (min-width: 1000px) {
   .gallery-carousel {
     display: flex;
     width: 964px;
@@ -72,7 +72,7 @@ button img {
   .gallery-item {
     display: none;
     flex: 1;
-    transition: transform 0.9s ease, opacity 0.9s ease; /* Зменшено до 0.3s для плавності */
+    transition: transform 0.9s ease, opacity 0.9s ease;
     transform: scale(0.9);
     opacity: 0;
     flex-shrink: 0;

--- a/src/scss/header.scss
+++ b/src/scss/header.scss
@@ -15,7 +15,7 @@
   margin: auto;
 }
 // Desktop header navigation styles
-@media screen and (min-width: 768px) {
+@media screen and (min-width: 1000px) {
   .header-nav-mobile {
     display: none;
   }
@@ -43,9 +43,6 @@
   align-items: center;
   justify-content: center;
   height: 100%;
-  font-weight: 500;
-  font-size: 20px;
-  line-height: 1.5;
   color: $_yellow_text_color;
 }
 .header-nav-list-item:not(:nth-child(4)) {
@@ -65,6 +62,11 @@
   justify-content: center;
   width: 100%;
   height: 100%;
+  font-family: 'Signika Negative';
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 32px; /* 180% */
 }
 .header-nav-link:hover,
 .header-nav-link:active,
@@ -79,7 +81,7 @@
 }
 
 // MOBILE MENU
-@media screen and (max-width: 767px) {
+@media screen and (max-width: 1000px) {
   .header-nav-mobile {
     display: flex;
     justify-content: space-between;
@@ -144,7 +146,11 @@
   }
 
   .header-nav-list-item-mobile {
-    font-size: 18px;
+    font-family: 'Signika Negative';
+    font-size: 20px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 36px; /* 180% */
     color: $_yellow_text_color;
   }
 

--- a/src/scss/home.scss
+++ b/src/scss/home.scss
@@ -3,7 +3,7 @@
   margin-top: 72px;
 }
 
-@media screen and (min-width: 1000px) {
+@media screen and (min-width: 1199px) {
   .home {
     min-height: 680px;
   }
@@ -27,7 +27,7 @@
   animation-delay: 0.2s; /* Поява першою */
 }
 
-@media screen and (min-width: 768px) {
+@media screen and (min-width: 1199px) {
   .home-image:first-child {
     margin-bottom: 10px;
     margin-top: 80px;
@@ -60,7 +60,7 @@ h1 {
   animation-delay: 0.6s; /* Поява третьою */
 }
 
-@media screen and (min-width: 768px) {
+@media screen and (min-width: 1199px) {
   h1 {
     margin-bottom: 56px;
   }

--- a/src/scss/howtoplay.scss
+++ b/src/scss/howtoplay.scss
@@ -1,4 +1,4 @@
-@media screen and (min-width: 768px) {
+@media screen and (min-width: 1000px) {
   .howtoplay {
     background: $_yellow_text_color;
   }
@@ -23,6 +23,7 @@
     background: #ffffff80;
     margin-bottom: 20px;
     border-radius: 8px;
+    margin-left: 98px;
   }
   .howtoplay-list-item:nth-child(even) {
     margin-left: auto;
@@ -43,7 +44,7 @@
   }
 }
 
-@media screen and (max-width: 767px) {
+@media screen and (max-width: 1000px) {
   .howtoplay {
     display: flex;
     background: $_yellow_text_color;

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -37,7 +37,6 @@ html {
 
 .container {
   min-width: 320px;
-
   margin: 0 auto; /* Центруємо контейнер */
   padding: 32px 20px;
   position: relative;


### PR DESCRIPTION
- коректні шрифти для навігації для ПК,  для бургер-меню та для футера
- прибрано перелом 768px. Вся анімація працює після перелому 1199px, додано проміжний перелом 1000px.
- додано відступи для контенту у секції howToPlay та aboutUs